### PR TITLE
Refactor department assignment to standalone

### DIFF
--- a/src/app/components/department-assignment/department-assignment.component.html
+++ b/src/app/components/department-assignment/department-assignment.component.html
@@ -1,19 +1,19 @@
-<div [ngClass]="{'rtl-direction' : isRtl}" >
-  <div class="dialog-heading-div" [ngClass]="{'text-right': isRtl}" appDraggableDialog>
-    <span class="page-title" [ngClass]="isRtl ? 'mr-4' : 'ml-4'">
-      {{ 'ASSIGN_TO_DEPARTMENT' | translate }} ({{selectedManagers.length}})
+<div [class.rtl-direction]="isRtl()" >
+  <div class="dialog-heading-div" [class.text-right]="isRtl()" appDraggableDialog>
+    <span class="page-title" [class.mr-4]="isRtl()" [class.ml-4]="!isRtl()">
+      {{ 'ASSIGN_TO_DEPARTMENT' | translate }} ({{ selectedCount() }})
     </span>
   </div>
   <mat-dialog-content class="mat-typography hide-mob">
     <mat-accordion multi="true">
       <mat-expansion-panel class="mt-3" *ngFor="let department of directoratesList; let i = index">
         <mat-expansion-panel-header>
-          <mat-panel-title [ngClass]="{'mr-0 ml-3': isRtl}">
+          <mat-panel-title [class.mr-0]="isRtl()" [class.ml-3]="!isRtl()">
             {{department.directorateName}}
           </mat-panel-title>
         </mat-expansion-panel-header>
         <table mat-table [dataSource]="department.managersList" class="mat-elevation-z8 w-100"
-          [ngClass]="{'text-right': isRtl}">
+          [class.text-right]="isRtl()">
           <ng-container matColumnDef="select">
             <th mat-header-cell *matHeaderCellDef></th>
             <td mat-cell *matCellDef="let row">
@@ -51,18 +51,18 @@
               </mat-form-field>
             </td>
           </ng-container>
-          <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-          <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+          <tr mat-header-row *matHeaderRowDef="displayedColumns()"></tr>
+          <tr mat-row *matRowDef="let row; columns: displayedColumns()"></tr>
         </table>
       </mat-expansion-panel>
     </mat-accordion>
-    <button class="mt-3 b-blue c-white" [ngClass]="{'float-right' : !isRtl}" mat-raised-button
-      *ngIf="!isGeneralCmntEnabled" (click)="removeTableComments()"> {{ 'ENABLE_GENERAL_COMMENT' | translate }}
+    <button class="mt-3 b-blue c-white" [class.float-right]="!isRtl()" mat-raised-button
+      *ngIf="!isGeneralCmntEnabled()" (click)="removeTableComments()"> {{ 'ENABLE_GENERAL_COMMENT' | translate }}
     </button>
-    <mat-toolbar class="gen-comment-toolbar mt-3 b-blue c-white" *ngIf="isGeneralCmntEnabled">
+    <mat-toolbar class="gen-comment-toolbar mt-3 b-blue c-white" *ngIf="isGeneralCmntEnabled()">
       <span>{{ 'GENERAL_COMMENT' | translate }}</span>
     </mat-toolbar>
-    <mat-form-field class="mt-3 w-100 text-right border-textarea" *ngIf="isGeneralCmntEnabled">
+    <mat-form-field class="mt-3 w-100 text-right border-textarea" *ngIf="isGeneralCmntEnabled()">
       <textarea matInput [(ngModel)]="groupComment" [matTextareaAutosize]=true [matAutosizeMinRows]=3
         [matAutosizeMaxRows]=5 #message maxlength="256"></textarea>
       <mat-hint align="end">{{message.value.trim().length}} / 256</mat-hint>
@@ -72,12 +72,12 @@
     <mat-accordion multi="true">
       <mat-expansion-panel class="mt-3" *ngFor="let department of directoratesList; let i = index">
         <mat-expansion-panel-header>
-          <mat-panel-title [ngClass]="{'mr-0 ml-3': isRtl}">
+          <mat-panel-title [class.mr-0]="isRtl()" [class.ml-3]="!isRtl()">
             {{department.directorateName}}
           </mat-panel-title>
         </mat-expansion-panel-header>
         <table class="w-100" mat-table [dataSource]="department.managersList" multiTemplateDataRows
-          [ngClass]="{'text-right': isRtl}">
+          [class.text-right]="isRtl()">
           <ng-container matColumnDef="select">
             <th mat-header-cell *matHeaderCellDef></th>
             <td mat-cell *matCellDef="let row">
@@ -97,11 +97,11 @@
                 <div>
                   <span>{{element.userName}}</span>
                 </div>
-                <div *ngIf="isGeneralCmntEnabled">
+                <div *ngIf="isGeneralCmntEnabled()">
                   <button mat-raised-button class="b-blue c-white" (click)="addTableComments()">
                     {{ 'COMMENT' | translate }}</button>
                 </div>
-                <div *ngIf="!isGeneralCmntEnabled">
+                <div *ngIf="!isGeneralCmntEnabled()">
                   <mat-form-field class="w-90 text-right">
                     <mat-label>{{ 'COMMENT_TO_MGR' | translate }}</mat-label>
                     <textarea matInput [(ngModel)]="element.comment" (change)="onAddManagerComment(element)" #message
@@ -118,12 +118,12 @@
         </table>
       </mat-expansion-panel>
     </mat-accordion>
-    <button class="mt-3 float-right b-blue c-white" mat-raised-button *ngIf="!isGeneralCmntEnabled"
+    <button class="mt-3 float-right b-blue c-white" mat-raised-button *ngIf="!isGeneralCmntEnabled()"
       (click)="removeTableComments()"> {{ 'ENABLE_GENERAL_COMMENT' | translate }} </button>
-    <mat-toolbar class="gen-comment-toolbar mt-3 b-blue c-white" *ngIf="isGeneralCmntEnabled">
+    <mat-toolbar class="gen-comment-toolbar mt-3 b-blue c-white" *ngIf="isGeneralCmntEnabled()">
       <span>{{ 'GENERAL_COMMENT' | translate }}</span>
     </mat-toolbar>
-    <mat-form-field class="mt-3 w-100 text-right border-textarea h-120" *ngIf="isGeneralCmntEnabled">
+    <mat-form-field class="mt-3 w-100 text-right border-textarea h-120" *ngIf="isGeneralCmntEnabled()">
       <textarea matInput [(ngModel)]="groupComment" [matTextareaAutosize]=true [matAutosizeMinRows]=3
         [matAutosizeMaxRows]=5 #message maxlength="256"></textarea>
       <mat-hint align="end">{{message.value.trim().length}} / 256</mat-hint>
@@ -131,8 +131,8 @@
   </mat-dialog-content>
   <mat-dialog-actions align="end">
     <button mat-raised-button mat-dialog-close>{{ 'CLOSE' | translate }}</button>
-    <button mat-raised-button class="b-blue c-white" (click)="onSendToDepartments()" [ngClass]="{'ml-0 mr-2' : isRtl}"
-      [disabled]="selectedManagers.length == 0 || (selectedManagers.length + noOfactiveDepts) == 0 || (selectedManagers.length + noOfactiveDepts) > 3">
+    <button mat-raised-button class="b-blue c-white" (click)="onSendToDepartments()" [class.ml-0]="isRtl()" [class.mr-2]="!isRtl()"
+      [disabled]="selectedCount() == 0 || (selectedCount() + noOfactiveDepts) == 0 || (selectedCount() + noOfactiveDepts) > 3">
       {{ 'ASSIGN' | translate }}</button>
   </mat-dialog-actions>
 </div>

--- a/src/app/components/department-assignment/department-assignment.component.scss
+++ b/src/app/components/department-assignment/department-assignment.component.scss
@@ -1,13 +1,4 @@
-.show-mob {
-  display: none;
-}
 
-.dialog-heading-div {
-  padding: 15px 0 15px 0px;
-  margin: 0 -24px 0 -24px;
-  background: #3253ab;
-  color: #ffffff;
-}
 
 .mat-expansion-panel-header.mat-expanded,
 .mat-expansion-panel-header.mat-expanded:hover,
@@ -50,53 +41,8 @@ td.mat-footer-cell {
   padding: 10px !important;
 }
 
-.gen-comment-toolbar {
-  height: 50px;
-  font-size: 15px;
-  padding: 0 24px;
-}
-
-.title-td {
-  font-weight: 600;
-  display: inline-block;
-  width: 250px;
-  white-space: nowrap;
-  overflow: hidden !important;
-  text-overflow: ellipsis;
-  margin: 10px 0 0 13px;
-}
-
-.expanded-td {
-  border-bottom: 1px solid rgba(0, 0, 0, .12) !important;
-}
-
-.expanded-div {
-  margin-top: -15px;
-  margin-bottom: 10px;
-  padding: 0 0 0 10%;
-}
-
-.w-90 {
-  width: 90%;
-}
-
-.rtl-direction th.mat-header-cell {
-  text-align: right !important;
-}
-
-.w-35 {
-  width: 35px;
-}
-
 
 @media(max-width: 767px) {
-  .hide-mob {
-    display: none;
-  }
-
-  .show-mob {
-    display: block;
-  }
 
   tr.mat-header-row {
     height: unset;
@@ -134,7 +80,7 @@ td.mat-footer-cell {
     padding-right: unset !important;
   }
 
-  .rtl-direction .title-td {    
+  .rtl-direction .title-td {
     margin: 10px 13px 0 0 !important;
   }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,6 +1,6 @@
 /* You can add global styles to this file, and also import other style files */
 .dialog-heading-div {
-  padding: 15px;
+  padding: 15px 0;
   margin: 0 -24px;
   background: #3253ab;
   color: #fff;
@@ -84,4 +84,22 @@
 
 .expanded-td {
   border-bottom: 1px solid rgba(0, 0, 0, 0.12) !important;
+}
+
+.gen-comment-toolbar {
+  height: 50px;
+  font-size: 15px;
+  padding: 0 24px;
+}
+
+.w-90 {
+  width: 90%;
+}
+
+.w-35 {
+  width: 35px;
+}
+
+.rtl-direction th.mat-header-cell {
+  text-align: right !important;
 }


### PR DESCRIPTION
## Summary
- migrate `department-assignment` component to standalone Angular 19 style
- use signals and injection helpers
- extract reusable styles to `styles.scss`
- clean component-specific styles

## Testing
- `npm test --silent` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d7cd6f504832aa8bff52ca781e2dc