### PR TITLE
Refactor delegation components

### DIFF
--- a/src/app/components/delegation/delegation.component.spec.ts
+++ b/src/app/components/delegation/delegation.component.spec.ts
@@ -8,7 +8,7 @@ describe('DelegationComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ DelegationComponent ]
+      imports: [DelegationComponent]
     })
     .compileComponents();
   });

--- a/src/app/components/delegation/delegation.component.ts
+++ b/src/app/components/delegation/delegation.component.ts
@@ -1,4 +1,11 @@
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  OnInit,
+  ViewChild,
+  inject,
+} from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { MomentDateAdapter, MAT_MOMENT_DATE_ADAPTER_OPTIONS } from '@angular/material-moment-adapter';
 import { DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE } from '@angular/material/core';
@@ -16,6 +23,7 @@ import { LoadingService } from 'src/app/services/loading.service';
 import { SharedVariableService } from 'src/app/services/shared-variable.service';
 import { ConfirmationDialogComponent } from '../confirmation-dialog/confirmation-dialog.component';
 import { EditDelegationDialogComponent } from './edit-delegation-dialog/edit-delegation-dialog.component';
+import { SharedModule } from '../../shared/modules/shared.module';
 
 export interface Users {
   loginId: number;
@@ -55,8 +63,11 @@ export const MY_FORMATS = {
 
 @Component({
   selector: 'app-delegation',
+  standalone: true,
   templateUrl: './delegation.component.html',
-  styleUrls: ['./delegation.component.css'],
+  styleUrls: ['./delegation.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [SharedModule],
   providers: [
     {
       provide: DateAdapter,
@@ -114,15 +125,12 @@ export class DelegationComponent implements OnInit {
   isDisable = true;
   selectedTab = "self";
   innerWidth = 0;
-  constructor(
-    private coreService: CoreService,
-    private sharedVariableService: SharedVariableService,
-    private fb: FormBuilder,
-    public dialog: MatDialog,
-    private _loading: LoadingService,
-    private notification: NzNotificationService,
-  ) {
-  }
+  private readonly coreService = inject(CoreService);
+  private readonly sharedVariableService = inject(SharedVariableService);
+  private readonly fb = inject(FormBuilder);
+  private readonly dialog = inject(MatDialog);
+  private readonly _loading = inject(LoadingService);
+  private readonly notification = inject(NzNotificationService);
 
   ngOnInit(): void {
     this.sharedVariableService.getRtlValue().subscribe((value) => {

--- a/src/app/components/delegation/edit-delegation-dialog/edit-delegation-dialog.component.spec.ts
+++ b/src/app/components/delegation/edit-delegation-dialog/edit-delegation-dialog.component.spec.ts
@@ -8,7 +8,7 @@ describe('EditDelegationDialogComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ EditDelegationDialogComponent ]
+      imports: [EditDelegationDialogComponent]
     })
     .compileComponents();
   });

--- a/src/app/components/delegation/edit-delegation-dialog/edit-delegation-dialog.component.ts
+++ b/src/app/components/delegation/edit-delegation-dialog/edit-delegation-dialog.component.ts
@@ -1,7 +1,13 @@
-import { Component, OnInit, Inject, ChangeDetectorRef } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  Inject,
+  inject,
+} from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MatDatepickerInputEvent } from '@angular/material/datepicker';
-import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { SharedVariableService } from 'src/app/services/shared-variable.service';
 import * as moment from 'moment';
 import { CoreService } from 'src/app/services/core.service';
@@ -9,6 +15,7 @@ import { LoadingService } from 'src/app/services/loading.service';
 import { NzNotificationService } from 'ng-zorro-antd/notification';
 import { MomentDateAdapter, MAT_MOMENT_DATE_ADAPTER_OPTIONS } from '@angular/material-moment-adapter';
 import { DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE } from '@angular/material/core';
+import { SharedModule } from '../../../shared/modules/shared.module';
 export const MY_FORMATS = {
   parse: {
     dateInput: 'LL'
@@ -22,8 +29,11 @@ export const MY_FORMATS = {
 };
 @Component({
   selector: 'app-edit-delegation-dialog',
+  standalone: true,
   templateUrl: './edit-delegation-dialog.component.html',
-  styleUrls: ['./edit-delegation-dialog.component.css'],
+  styleUrls: ['./edit-delegation-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [SharedModule],
   providers: [
     {
       provide: DateAdapter,
@@ -45,11 +55,13 @@ export class EditDelegationDialogComponent implements OnInit {
   updateData: any;
   isButtonDisabled = false;
   msg: any = '';
-  constructor(private sharedVariableService: SharedVariableService, private fb: FormBuilder, private coreService: CoreService,
-    private _loading: LoadingService,
-    private notification: NzNotificationService,
-    public dialogRef: MatDialogRef<EditDelegationDialogComponent>, private ref: ChangeDetectorRef,
-    @Inject(MAT_DIALOG_DATA) public data: any) { }
+  private readonly sharedVariableService = inject(SharedVariableService);
+  private readonly fb = inject(FormBuilder);
+  private readonly coreService = inject(CoreService);
+  private readonly _loading = inject(LoadingService);
+  private readonly notification = inject(NzNotificationService);
+  readonly dialogRef = inject(MatDialogRef<EditDelegationDialogComponent>);
+  constructor(@Inject(MAT_DIALOG_DATA) public data: any) {}
 
   ngOnInit(): void {
     const updateData = this.data;
@@ -93,7 +105,6 @@ export class EditDelegationDialogComponent implements OnInit {
         console.log(this.msg );
       }
 
-      // this.ref.detectChanges();
 
     } 
   }


### PR DESCRIPTION
## Summary
- convert DelegationComponent and EditDelegationDialogComponent to standalone components
- use inject for services and set OnPush change detection
- update style urls to scss
- adjust specs for standalone setup

## Testing
- `npx ng test --watch=false` *(fails: could not determine executable)*

------
https://chatgpt.com/codex/tasks/task_e_684d7f82eeb0832ab629729de5815945