### PR TITLE
Refactor Add Comment component to Angular 19 style

### DIFF
--- a/src/app/components/add-comment/add-comment.component.html
+++ b/src/app/components/add-comment/add-comment.component.html
@@ -1,14 +1,14 @@
-<div [class.rtl-direction]="isRtl$ | async">
+<div [class.rtl-direction]="isRtl()">
   <div
     cdkDrag
     cdkDragRootElement=".mat-dialog-container"
     class="dialog-heading-div"
-    [class.text-right]="isRtl$ | async"
+    [class.text-right]="isRtl()"
   >
     <span
       class="page-title"
-      [class.ml-4]="!(isRtl$ | async)"
-      [class.mr-4]="isRtl$ | async"
+      [class.ml-4]="!isRtl()"
+      [class.mr-4]="isRtl()"
     >
       Add Comment
     </span>
@@ -35,7 +35,7 @@
           cdkAutosizeMaxRows="5"
         ></textarea>
         <mat-hint align="end">
-          {{ form.value.comment?.trim()?.length || 0 }} / {{ maxLen }}
+          {{ form.value.comment?.trim()?.length || 0 }} / {{ maxLen() }}
         </mat-hint>
       </mat-form-field>
     </div>

--- a/src/app/components/add-comment/add-comment.component.scss
+++ b/src/app/components/add-comment/add-comment.component.scss
@@ -1,45 +1,11 @@
-/* add-comment.component.scss */
 :host {
   display: block;
-}
-
-.dialog-heading-div {
-  padding: 15px;
-  margin: 0 -24px;
-  background: #3253ab;
-  color: #fff;
-  cursor: move;
 }
 
 .mat-dialog-content.custom-height {
   height: 170px;
 }
 
-.h-120 {
-  min-height: 120px;
-}
-
 .mat-dialog-container {
   height: 80%;
 }
-
-.border-textarea .mat-form-field-wrapper {
-  border: 1px solid rgba(0, 0, 0, 0.23);
-  border-radius: 4px;
-}
-
-.rtl-direction {
-  direction: rtl;
-}
-
-.text-right {
-  text-align: right;
-}
-
-/* spacing utilities (you can extract to global styles if desired) */
-.ml-4 { margin-left: 1rem !important; }
-.mr-4 { margin-right: 1rem !important; }
-.mt-3 { margin-top: 1rem !important; }
-.mt-n3 { margin-top: -1rem !important; }
-.pt-3 { padding-top: 1rem !important; }
-.w-100 { width: 100% !important; }

--- a/src/app/components/add-comment/add-comment.component.ts
+++ b/src/app/components/add-comment/add-comment.component.ts
@@ -1,5 +1,11 @@
 import { CommonModule } from '@angular/common';
-import { Component, Inject, OnInit } from '@angular/core';
+import {
+  Component,
+  Inject,
+  OnInit,
+  computed,
+  signal,
+} from '@angular/core';
 import {
   ReactiveFormsModule,
   FormControl,
@@ -18,8 +24,9 @@ import { MatInputModule } from '@angular/material/input';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { TranslateModule } from '@ngx-translate/core';
 import { SharedVariableService } from '../../services/shared-variable.service';
-import { Observable } from 'rxjs';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { ObsResponse } from '../../models/obs-response.model';
+import { CommentConfigService } from '../../services/comment-config.service';
 
 @Component({
   selector: 'app-add-comment',
@@ -38,34 +45,42 @@ import { ObsResponse } from '../../models/obs-response.model';
   styleUrls: ['./add-comment.component.scss'],
 })
 export class AddCommentComponent implements OnInit {
-  form!: FormGroup;
-  isAdmin = false;
-  isRtl$: Observable<any>;
+  isAdmin = signal(false);
+  readonly isRtl = toSignal(this.sharedVariableService.isRtl$, {
+    initialValue: false,
+  });
+  readonly maxLenSignal = computed(() =>
+    this.isAdmin() ? this.config.adminMaxLength : this.config.userMaxLength
+  );
+
+  form!: FormGroup<{ comment: FormControl<string> }>;
+
   constructor(
     private dialogRef: MatDialogRef<AddCommentComponent>,
     @Inject(MAT_DIALOG_DATA) public data: ObsResponse,
-    private sharedVariableService: SharedVariableService
+    private sharedVariableService: SharedVariableService,
+    private config: CommentConfigService
   ) {
     this.dialogRef.disableClose = true;
-    this.isRtl$ = this.sharedVariableService.isRtl$;
   }
 
   ngOnInit(): void {
     const userInfo = JSON.parse(
       localStorage.getItem('sabUserInformation') || '{}'
     );
-    this.isAdmin = !!userInfo.admin;
+    this.isAdmin.set(!!userInfo.admin);
 
-    this.form = new FormGroup({
-      comment: new FormControl('', [
-        Validators.required,
-        Validators.maxLength(this.isAdmin ? 1000 : 256),
-      ]),
+    this.form = new FormGroup<{ comment: FormControl<string> }>({
+      comment: new FormControl('', {
+        nonNullable: true,
+        validators: [Validators.required, Validators.maxLength(this.maxLenSignal())],
+      }),
     });
   }
 
-  get maxLen(): number {
-    return this.isAdmin ? 1000 : 256;
+
+  maxLen(): number {
+    return this.maxLenSignal();
   }
 
   onSend(): void {

--- a/src/app/services/comment-config.service.ts
+++ b/src/app/services/comment-config.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class CommentConfigService {
+  adminMaxLength = 1000;
+  userMaxLength = 256;
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -103,3 +103,36 @@
 .rtl-direction th.mat-header-cell {
   text-align: right !important;
 }
+
+.h-120 {
+  min-height: 120px;
+}
+
+.border-textarea .mat-form-field-wrapper {
+  border: 1px solid rgba(0, 0, 0, 0.23);
+  border-radius: 4px;
+}
+
+.ml-4 {
+  margin-left: 1rem !important;
+}
+
+.mr-4 {
+  margin-right: 1rem !important;
+}
+
+.mt-3 {
+  margin-top: 1rem !important;
+}
+
+.mt-n3 {
+  margin-top: -1rem !important;
+}
+
+.pt-3 {
+  padding-top: 1rem !important;
+}
+
+.w-100 {
+  width: 100% !important;
+}


### PR DESCRIPTION
## Summary
- migrate AddCommentComponent to use signals and typed forms
- add shared comment config service
- move common styles to `styles.scss`
- clean up AddComment styles

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d82405ea8832abfcaf36e6415e0bb