### PR TITLE
Refactor delegation components for Angular 19

### DIFF
--- a/src/app/components/delegation/delegation.component.html
+++ b/src/app/components/delegation/delegation.component.html
@@ -1,4 +1,4 @@
-<div class="container-flud" (window:resize)="onResize($event)" >
+<div class="container-flud">
   <mat-card class="main-card">
     <div class="row">
       <div class="col-12 mb-3" [ngClass]="{'text-right': isRtl}">

--- a/src/app/components/delegation/delegation.component.ts
+++ b/src/app/components/delegation/delegation.component.ts
@@ -26,30 +26,7 @@ import { EditDelegationDialogComponent } from './edit-delegation-dialog/edit-del
 import { CoreService } from '../../services/core.service';
 import { LoadingService } from '../../services/loading.service';
 import { SharedVariableService } from '../../services/shared-variable.service';
-
-export interface Users {
-  loginId: number | string;
-  userName: string;
-  directorateName: string;
-  department: string;
-  designation: string;
-}
-
-export interface DelegatedUsers {
-  id: number;
-  fromLoginId: string;
-  toLoginId: string;
-  fromUserName: string;
-  toUserName: string;
-  delegationFrom: string; // 'DD/MM/YYYY'
-  delegationTo: string;   // 'DD/MM/YYYY'
-  delegateFrom: string;
-  active: boolean;
-  deleted: boolean;
-  delegationReason: string;
-  createDate: string;
-  addedByUserName: string;
-}
+import { DelegatedUser, UserLookup } from '../../models/delegation.model';
 
 @Component({
   standalone: true,
@@ -70,8 +47,20 @@ export class DelegationComponent implements OnInit, OnDestroy {
   isRtl = false;
 
   /** Main forms for “self” delegation & “others” delegation */
-  addDelegateUserForm!: FormGroup;
-  addToDelegateForm!: FormGroup;
+  addDelegateUserForm!: FormGroup<{
+    delegateUser: FormControl<UserLookup | null>;
+    from: FormControl<Date | null>;
+    to: FormControl<Date | null>;
+    reason: FormControl<string | null>;
+  }>;
+
+  addToDelegateForm!: FormGroup<{
+    userData: FormControl<UserLookup | null>;
+    delegateUserData: FormControl<UserLookup | null>;
+    from: FormControl<Date | null>;
+    to: FormControl<Date | null>;
+    reason: FormControl<string | null>;
+  }>;
 
   /** Holds the user info from localStorage */
   userInformation: any;
@@ -90,7 +79,7 @@ export class DelegationComponent implements OnInit, OnDestroy {
   isToDisable = true;
 
   /** Table data sources */
-  dataSource!: MatTableDataSource<DelegatedUsers>;
+  dataSource!: MatTableDataSource<DelegatedUser>;
   displayedColumns: string[] = [
     'delegateFrom',
     'user',
@@ -103,9 +92,9 @@ export class DelegationComponent implements OnInit, OnDestroy {
   displayedColumnsMob: string[] = ['delegateFrom'];
 
   /** Observables for user lookups */
-  filteredUser!: Observable<Users[]>;
-  filteredUserData!: Observable<Users[]>;
-  filteredDelegateData!: Observable<Users[]>;
+  filteredUser!: Observable<UserLookup[]>;
+  filteredUserData!: Observable<UserLookup[]>;
+  filteredDelegateData!: Observable<UserLookup[]>;
 
   /** Additional state / flags */
   innerWidth = 0; // track window size
@@ -114,9 +103,6 @@ export class DelegationComponent implements OnInit, OnDestroy {
   isDisable = true;
   selectedTab: 'self' | 'others' = 'self';
 
-  /** Form controls for “others” delegation */
-  userData = new FormControl();          // from
-  delegateUserData = new FormControl();  // to
 
   /** Local references for user input elements */
   @ViewChild('userInput') userInput!: ElementRef<HTMLInputElement>;
@@ -127,6 +113,10 @@ export class DelegationComponent implements OnInit, OnDestroy {
 
   /** A subject for unsubscribing from streams on destroy */
   private readonly destroy$ = new Subject<void>();
+
+  private get delegateUserDataControl(): FormControl<UserLookup | null> {
+    return this.addToDelegateForm.get('delegateUserData') as FormControl<UserLookup | null>;
+  }
 
   constructor(
     @Inject(LOCALE_ID) private locale: string,
@@ -202,25 +192,30 @@ export class DelegationComponent implements OnInit, OnDestroy {
     this.innerWidth = window.innerWidth;
   }
 
+  /** Display function for autocomplete selections */
+  displayFn(user: UserLookup | null): string {
+    return user ? `${user.userName} (${user.loginId})` : '';
+  }
+
   /**
    * Construct reactive forms for “self” delegation & “others” delegation.
    */
   private buildForms(): void {
     // Self Delegation Form
     this.addDelegateUserForm = this.fb.group({
-      delegateUser: [null, [Validators.required]],
-      from: [null, [Validators.required]],
-      to: [null, [Validators.required]],
-      reason: [null]
+      delegateUser: this.fb.control<UserLookup | null>(null, Validators.required),
+      from: this.fb.control<Date | null>(null, Validators.required),
+      to: this.fb.control<Date | null>(null, Validators.required),
+      reason: this.fb.control<string | null>(null)
     });
 
     // Delegation to Others
     this.addToDelegateForm = this.fb.group({
-      userData: [null, [Validators.required]],
-      delegateUserData: [{ value: null, disabled: this.isDisable }, [Validators.required]],
-      from: [null, [Validators.required]],
-      to: [null, [Validators.required]],
-      reason: [null]
+      userData: this.fb.control<UserLookup | null>(null, Validators.required),
+      delegateUserData: this.fb.control<UserLookup | null>({ value: null, disabled: this.isDisable }, Validators.required),
+      from: this.fb.control<Date | null>(null, Validators.required),
+      to: this.fb.control<Date | null>(null, Validators.required),
+      reason: this.fb.control<string | null>(null)
     });
   }
 
@@ -245,7 +240,7 @@ export class DelegationComponent implements OnInit, OnDestroy {
 
     this.isLoading = true;
     this.loadingService.setLoading(true, url);
-    this.coreService.get<DelegatedUsers[]>(url).subscribe({
+    this.coreService.get<DelegatedUser[]>(url).subscribe({
       next: (response) => {
         this.isLoading = false;
         this.loadingService.setLoading(false, url);
@@ -283,7 +278,7 @@ export class DelegationComponent implements OnInit, OnDestroy {
 
     this.isLoading = true;
     this.loadingService.setLoading(true, url);
-    this.coreService.get<DelegatedUsers[]>(url).subscribe({
+    this.coreService.get<DelegatedUser[]>(url).subscribe({
       next: (response) => {
         this.isLoading = false;
         this.loadingService.setLoading(false, url);
@@ -509,7 +504,7 @@ export class DelegationComponent implements OnInit, OnDestroy {
     }
 
     this.loadingService.setLoading(true, url);
-    this.coreService.get<Users[]>(url).subscribe({
+    this.coreService.get<UserLookup[]>(url).subscribe({
       next: (response) => {
         this.isLoading = false;
         this.loadingService.setLoading(false, url);
@@ -572,7 +567,7 @@ export class DelegationComponent implements OnInit, OnDestroy {
     }
 
     const url = `UserController/getDelegationUsersList?currentUserId=${selected.loginId}`;
-    this.coreService.get<Users[]>(url).subscribe({
+    this.coreService.get<UserLookup[]>(url).subscribe({
       next: (response) => {
         // This is the "to" user array
         const allDelegateUsers = response;
@@ -619,7 +614,7 @@ export class DelegationComponent implements OnInit, OnDestroy {
   /**
    * Delete an existing delegation after user confirmation.
    */
-  deleteDelegation(delegation: DelegatedUsers): void {
+  deleteDelegation(delegation: DelegatedUser): void {
     const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
       data: {
         dialogHeader: 'DELETE',
@@ -670,7 +665,7 @@ export class DelegationComponent implements OnInit, OnDestroy {
   /**
    * Edit an existing delegation. Opens a dialog, then refreshes data upon close.
    */
-  editDelegation(delegation: DelegatedUsers): void {
+  editDelegation(delegation: DelegatedUser): void {
     const dialogRef = this.dialog.open(EditDelegationDialogComponent, {
       width: '800px',
       data: JSON.stringify(delegation)

--- a/src/app/components/delegation/edit-delegation-dialog/edit-delegation-dialog.component.ts
+++ b/src/app/components/delegation/edit-delegation-dialog/edit-delegation-dialog.component.ts
@@ -1,55 +1,52 @@
-import { Component, OnInit, Inject, ChangeDetectorRef } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Component, Inject, OnInit, LOCALE_ID } from '@angular/core';
 import { MatDatepickerInputEvent } from '@angular/material/datepicker';
-import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
-import { SharedVariableService } from 'src/app/services/shared-variable.service';
-import * as moment from 'moment';
+import { MAT_DIALOG_DATA, MatDialogRef, MatDialogModule } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule } from '@angular/material/core';
+import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { DraggableDialogDirective } from '../../../shared/directives/draggable-dialog.directive';
+import { format } from 'date-fns';
 import { CoreService } from 'src/app/services/core.service';
 import { LoadingService } from 'src/app/services/loading.service';
 import { NzNotificationService } from 'ng-zorro-antd/notification';
-import { MomentDateAdapter, MAT_MOMENT_DATE_ADAPTER_OPTIONS } from '@angular/material-moment-adapter';
-import { DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE } from '@angular/material/core';
-export const MY_FORMATS = {
-  parse: {
-    dateInput: 'LL'
-  },
-  display: {
-    dateInput: 'DD/MM/YYYY',
-    monthYearLabel: 'YYYY',
-    dateA11yLabel: 'LL',
-    monthYearA11yLabel: 'YYYY'
-  }
-};
+import { DelegatedUser } from '../../../models/delegation.model';
 @Component({
   selector: 'app-edit-delegation-dialog',
+  standalone: true,
   templateUrl: './edit-delegation-dialog.component.html',
   styleUrls: ['./edit-delegation-dialog.component.scss'],
-  providers: [
-    {
-      provide: DateAdapter,
-      useClass: MomentDateAdapter,
-      deps: [MAT_DATE_LOCALE, MAT_MOMENT_DATE_ADAPTER_OPTIONS]
-    },
-    { provide: MAT_DATE_FORMATS, useValue: MY_FORMATS },
-  ]
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
+    DraggableDialogDirective
+  ],
+  providers: [{ provide: LOCALE_ID, useValue: 'en-GB' }]
 })
 export class EditDelegationDialogComponent implements OnInit {
-  delegateFrom: any;
   minDate = new Date();
   minToDate = new Date();
   isToDisable = true;
-  editDelegateUserForm: FormGroup;
   isLoading: boolean = false;
-  fromDate: any;
-  toDate: any;
-  updateData: any;
+  updateData!: DelegatedUser;
   isButtonDisabled = false;
-  msg: any = '';
-  constructor(private sharedVariableService: SharedVariableService, private fb: FormBuilder, private coreService: CoreService,
+  msg = '';
+  constructor(
+    private coreService: CoreService,
     private _loading: LoadingService,
     private notification: NzNotificationService,
-    public dialogRef: MatDialogRef<EditDelegationDialogComponent>, private ref: ChangeDetectorRef,
-    @Inject(MAT_DIALOG_DATA) public data: any) { }
+    public dialogRef: MatDialogRef<EditDelegationDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: any
+  ) { }
 
   ngOnInit(): void {
     const updateData = this.data;
@@ -99,21 +96,21 @@ export class EditDelegationDialogComponent implements OnInit {
   }
 
   editDelegateUser() {
-    let url = 'UserController/updateDelegation'
-    let body = {
+    const url = 'UserController/updateDelegation';
+    const body = {
       id: this.updateData.id,
       addedLoginId: this.updateData.addedByLoginId,
       addedUserName: this.updateData.addedByUserName,
-      delegateFrom: moment(new Date(this.updateData.delegationFrom).toString()).format('DD/MM/YYYY'),
+      delegateFrom: format(new Date(this.updateData.delegationFrom), 'dd/MM/yyyy'),
       delegateReason: this.updateData.delegationReason,
-      delegateTo: moment(new Date(this.updateData.delegationTo).toString()).format('DD/MM/YYYY'),
+      delegateTo: format(new Date(this.updateData.delegationTo), 'dd/MM/yyyy'),
       fromJobTitle: this.updateData.fromJobTitle,
       fromLoginId: this.updateData.fromLoginId,
       fromUserName: this.updateData.fromUserName,
       toJobTitle: this.updateData.toJobTitle,
       toLoginId: this.updateData.toLoginId,
       toUserName: this.updateData.toUserName
-    }
+    };
     this.coreService.post(url, body).subscribe(response => {
       console.log(response);
       

--- a/src/app/models/delegation.model.ts
+++ b/src/app/models/delegation.model.ts
@@ -1,0 +1,23 @@
+export interface DelegatedUser {
+  id: number;
+  fromLoginId: string;
+  toLoginId: string;
+  fromUserName: string;
+  toUserName: string;
+  delegationFrom: string; // 'DD/MM/YYYY'
+  delegationTo: string;   // 'DD/MM/YYYY'
+  delegateFrom: string;
+  active: boolean;
+  deleted: boolean;
+  delegationReason: string;
+  createDate: string;
+  addedByUserName: string;
+}
+
+export interface UserLookup {
+  loginId: number | string;
+  userName: string;
+  directorateName: string;
+  department: string;
+  designation: string;
+}


### PR DESCRIPTION
## Summary
- introduce `DelegatedUser` and `UserLookup` models
- type reactive forms in `DelegationComponent`
- update delegation dialog to standalone component using date-fns
- remove moment and old Material adapters
- define `displayFn` helper and clean up resize handling

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e83ede8e0832a8a9640e132b45873